### PR TITLE
Fix duplicate AI report call

### DIFF
--- a/app.js
+++ b/app.js
@@ -324,7 +324,6 @@ async function loadData(uid) {
   if (firstMeasurement) {
     lastMeasurement = firstMeasurement;
     showAIReport(firstMeasurement);
-    showAIReport(lastMeasurement);
   } else {
     lastMeasurement = null;
     aiAdviceBox.classList.remove('disabled');


### PR DESCRIPTION
## Summary
- avoid calling `showAIReport` twice when loading measurements

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6840438377fc8323a577d261c4956735