### PR TITLE
Show profile username

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,13 @@
       transition: transform 0.3s ease;
     }
 
+    #profile-username {
+      color: #1e40af;
+      font-weight: 700;
+      font-family: 'Raleway', sans-serif;
+      font-size: 1rem;
+    }
+
     #header-section {
       max-width: 960px;
       margin: 1rem auto 2rem;
@@ -290,6 +297,7 @@
         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-blue-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true" aria-label="Settings icon">
           <path stroke-linecap="round" stroke-linejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0a1.724 1.724 0 002.602 1.086c.833-.58 1.797.197 1.431 1.1a1.724 1.724 0 001.462 2.457c.947.114 1.208 1.441.39 1.942a1.724 1.724 0 00.292 2.797c.818.442.34 1.842-.717 1.56a1.724 1.724 0 00-1.705 1.052c-.338.795-1.518.795-1.856 0a1.724 1.724 0 00-1.705-1.052c-1.057.282-1.536-1.118-.718-1.56a1.724 1.724 0 00.291-2.797c-.817-.5-1.24-1.828-.39-1.942a1.724 1.724 0 001.462-2.457c-.366-.903.598-1.68 1.431-1.1a1.724 1.724 0 002.602-1.086z" />
         </svg>
+        <span id="profile-username"></span>
         <svg xmlns="http://www.w3.org/2000/svg" id="profile-arrow" class="h-4 w-4 text-blue-700 transition-transform duration-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
         </svg>


### PR DESCRIPTION
## Summary
- display profile username in the navbar
- add styling for the username text

## Testing
- `node -e "console.log('node works')"`


------
https://chatgpt.com/codex/tasks/task_e_6840437c46e883238732186534f5d771