### PR TITLE
Improve UI with Apple-style design

### DIFF
--- a/app.js
+++ b/app.js
@@ -135,12 +135,12 @@ onAuthStateChanged(auth, async (user) => {
       if (!profileDoc.empty) {
         const data = profileDoc.docs[0].data();
         currentUserData = data;
-        profileUsername.textContent = data.username || user.email;
+        if (profileUsername) profileUsername.textContent = data.username || user.email;
       } else {
-        profileUsername.textContent = user.email;
+        if (profileUsername) profileUsername.textContent = user.email;
       }
     } catch {
-      profileUsername.textContent = user.email;
+      if (profileUsername) profileUsername.textContent = user.email;
     }
 
     loadData(user.uid);

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     body {
       background: linear-gradient(to bottom, #1e3a8a, #2563eb);
       color: #1f2937;
-      font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, Arial, sans-serif;
       min-height: 100vh;
       margin: 0;
       padding-top: 56px;
@@ -54,12 +54,9 @@
       margin-left: auto;
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.25rem;
       cursor: pointer;
       color: #1e40af;
-      font-weight: 700;
-      font-family: 'Raleway', sans-serif;
-      font-size: 1rem;
       user-select: none;
     }
 
@@ -90,8 +87,8 @@
     }
 
     .settings-icon {
-      width: 1rem;
-      height: 1rem;
+      width: 1.5rem;
+      height: 1.5rem;
     }
 
     #header-section {
@@ -212,9 +209,10 @@
     }
 
     #ai-status-meter {
-      height: 12px;
+      height: 8px;
       background: linear-gradient(to right, #10b981, #facc15, #dc2626);
       position: relative;
+      border-radius: 9999px;
     }
 
     #ai-status-arrow {
@@ -307,8 +305,7 @@
         <span class="text-xl font-bold text-blue-700 select-none">BubbleLog</span>
       </div>
 
-      <div id="profile-name-dropdown" tabindex="0" aria-haspopup="true" aria-expanded="false" role="button" aria-controls="profile-dropdown" class="flex items-center cursor-pointer select-none ml-auto gap-2">
-        <span id="profile-username" class="font-semibold text-blue-700"></span>
+      <div id="profile-name-dropdown" tabindex="0" aria-haspopup="true" aria-expanded="false" role="button" aria-controls="profile-dropdown" class="flex items-center cursor-pointer select-none ml-auto gap-1 pr-1">
         <svg xmlns="http://www.w3.org/2000/svg" class="settings-icon text-blue-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true" aria-label="Settings icon">
           <path stroke-linecap="round" stroke-linejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0a1.724 1.724 0 002.602 1.086c.833-.58 1.797.197 1.431 1.1a1.724 1.724 0 001.462 2.457c.947.114 1.208 1.441.39 1.942a1.724 1.724 0 00.292 2.797c.818.442.34 1.842-.717 1.56a1.724 1.724 0 00-1.705 1.052c-.338.795-1.518.795-1.856 0a1.724 1.724 0 00-1.705-1.052c-1.057.282-1.536-1.118-.718-1.56a1.724 1.724 0 00.291-2.797c-.817-.5-1.24-1.828-.39-1.942a1.724 1.724 0 001.462-2.457c-.366-.903.598-1.68 1.431-1.1a1.724 1.724 0 002.602-1.086z" />
         </svg>
@@ -388,8 +385,8 @@
         <canvas id="chart-co2" class="flex-grow min-w-[300px] max-w-[48%]" style="min-height:250px;"></canvas>
       </div>
 
-      <div id="ai-advice-box" class="max-w-xl mx-auto mt-4 p-4 rounded-xl shadow-lg text-gray-900 text-center disabled" aria-disabled="true" tabindex="-1">
-        <p class="font-semibold text-lg mb-2">AI Water Quality Advice</p>
+      <div id="ai-advice-box" class="max-w-xl mx-auto mt-4 p-6 rounded-2xl shadow-2xl text-gray-900 text-center bg-white bg-opacity-70 backdrop-filter backdrop-blur-md disabled" aria-disabled="true" tabindex="-1" style="transition:background-color 0.3s">
+        <p class="font-semibold text-lg mb-4">AI Water Quality Advice</p>
         <div id="ai-status-meter" class="relative w-full max-w-md mx-auto rounded-full">
           <div id="ai-status-arrow" class="hidden"></div>
         </div>


### PR DESCRIPTION
## Summary
- remove visible username in navigation bar and show settings icon instead
- tweak nav and AI analysis panel styling for a sleek Apple-like look
- handle missing profile name element in JS

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68405086f28883239caba93e5e5d6c83