### PR TITLE
Improve account menu display of logged in user

### DIFF
--- a/app.js
+++ b/app.js
@@ -148,6 +148,7 @@ onAuthStateChanged(auth, async (user) => {
     authContainer.classList.remove('hidden');
     dashboard.classList.add('hidden');
     profileContainer.style.display = 'none';
+    if (profileUsername) profileUsername.textContent = '';
     currentUserData = null;
     lastMeasurement = null;
   }

--- a/index.html
+++ b/index.html
@@ -315,6 +315,7 @@
       </div>
 
       <div id="profile-dropdown" role="menu" aria-label="User menu" class="hidden">
+        <div class="px-4 py-2 text-sm text-blue-700 border-b border-blue-200" id="profile-username"></div>
         <button id="logout-button" role="menuitem" class="block w-full text-left px-4 py-2 hover:bg-blue-100 focus:outline-none">Logout</button>
         <button id="contact-developer" role="menuitem" class="block w-full text-left px-4 py-2 hover:bg-blue-100 focus:outline-none">Contact Developer</button>
       </div>


### PR DESCRIPTION
## Summary
- show logged in username inside the account dropdown
- clear username display when signing out

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840577bdcf08323bdf4121954a62b6a