### PR TITLE
Add iOS PWA support

### DIFF
--- a/app.js
+++ b/app.js
@@ -470,4 +470,12 @@ filterDate.addEventListener('change', () => {
   if (user) loadData(user.uid);
 });
 
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('./service-worker.js').catch((err) => {
+      console.error('ServiceWorker registration failed:', err);
+    });
+  });
+}
+
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>BubbleLog</title>
-  <link rel="apple-touch-icon" href="apple-touch-icon.png">
+  <link rel="apple-touch-icon" href="apple-touch-icon.png" />
+  <link rel="manifest" href="manifest.json" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+  <meta name="theme-color" content="#2563eb" />
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <style>
@@ -342,6 +346,10 @@
   </style>
 </head>
 <body>
+  <div id="ios-install" class="hidden fixed bottom-0 left-0 right-0 bg-blue-600 text-white text-sm p-3 flex items-center justify-center z-50">
+    Tap 'Share' → 'Add to Home Screen' to use BubbleLog as an app on your device!
+    <button id="ios-install-close" class="ml-3 text-white">&times;</button>
+  </div>
   <nav>
     <div id="profile-container" role="navigation" aria-label="Main Navigation">
       <div class="logo-font flex items-center gap-2" aria-label="App logo">
@@ -503,5 +511,18 @@
   </footer>
 
   <script type="module" src="app.js"></script>
+  <script>
+    function showIosBanner() {
+      const isIos = /iphone|ipad|ipod/i.test(navigator.userAgent);
+      const isInStandalone = window.navigator.standalone === true;
+      if (isIos && !isInStandalone) {
+        const banner = document.getElementById('ios-install');
+        const closeBtn = document.getElementById('ios-install-close');
+        banner.classList.remove('hidden');
+        closeBtn.addEventListener('click', () => banner.classList.add('hidden'));
+      }
+    }
+    window.addEventListener('load', showIosBanner);
+  </script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "BubbleLog",
+  "short_name": "BubbleLog",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#1e3a8a",
+  "theme_color": "#2563eb",
+  "icons": [
+    {
+      "src": "apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,24 @@
+const CACHE_NAME = 'bubblelog-cache-v1';
+const urlsToCache = [
+  './',
+  './index.html',
+  './app.js',
+  './apple-touch-icon.png',
+  './manifest.json',
+  'https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css',
+  'https://cdn.jsdelivr.net/npm/chart.js'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => {
+      return response || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add web manifest and service worker
- register service worker in `app.js`
- show install banner for iPhone users
- include PWA meta tags in `index.html`

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_684149d3ff18832394d27314bec48daf