### PR TITLE
Fix auth init crash

### DIFF
--- a/app.js
+++ b/app.js
@@ -94,6 +94,7 @@ function setLanguage(lang) {
 }
 
 const savedLang = localStorage.getItem('lang') || 'en';
+let currentLang = savedLang;
 if (languageToggle) {
   const arrow = document.getElementById('language-arrow');
   languageToggle.addEventListener('click', () => {
@@ -122,6 +123,7 @@ if (languageToggle) {
   });
 
   setLanguage(savedLang);
+  updateAuthTexts(savedLang);
 }
 
 let isRegister = false;


### PR DESCRIPTION
## Summary
- fix script crash by declaring `currentLang`
- update auth text on language initialization

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68414fedf39c832397d543a77bc3003b