### PR TITLE
Improve iOS install prompt

### DIFF
--- a/app.js
+++ b/app.js
@@ -155,6 +155,7 @@ onAuthStateChanged(auth, async (user) => {
     dashboard.classList.remove('hidden');
     if (welcomeInfo) welcomeInfo.classList.remove('hidden');
     profileContainer.style.display = 'flex';
+    if (window.showIosBanner) window.showIosBanner();
 
     try {
       const profileDoc = await getDocs(query(collection(db, `users/${user.uid}/profile`)));

--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@
 <body>
   <div id="ios-install" class="hidden fixed bottom-0 left-0 right-0 bg-blue-600 text-white text-sm p-3 flex items-center justify-center z-50">
     Tap 'Share' → 'Add to Home Screen' to use BubbleLog as an app on your device!
-    <button id="ios-install-close" class="ml-3 text-white">&times;</button>
+    <button id="ios-install-close" class="ml-3 text-white text-2xl leading-none px-2 py-1 rounded-full hover:bg-blue-700 focus:outline-none" aria-label="Close banner">&times;</button>
   </div>
   <nav>
     <div id="profile-container" role="navigation" aria-label="Main Navigation">
@@ -444,17 +444,19 @@
 
   <script type="module" src="app.js"></script>
   <script>
-    function showIosBanner() {
+    window.showIosBanner = function() {
       const isIos = /iphone|ipad|ipod/i.test(navigator.userAgent);
       const isInStandalone = window.navigator.standalone === true;
-      if (isIos && !isInStandalone) {
+      if (isIos && !isInStandalone && !localStorage.getItem('iosBannerDismissed')) {
         const banner = document.getElementById('ios-install');
         const closeBtn = document.getElementById('ios-install-close');
         banner.classList.remove('hidden');
-        closeBtn.addEventListener('click', () => banner.classList.add('hidden'));
+        closeBtn.addEventListener('click', () => {
+          banner.classList.add('hidden');
+          localStorage.setItem('iosBannerDismissed', 'true');
+        }, { once: true });
       }
-    }
-    window.addEventListener('load', showIosBanner);
+    };
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enlarge the close button for the iOS install banner
- persist dismissal of the install banner in localStorage
- show banner after login only once per device

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841558de29c832382faac3f7fe53ba2