### PR TITLE
Make navigation text and icons white

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       justify-content: space-between;
       align-items: center;
       padding: 0.75rem 1rem;
-      color: #1e40af;
+      color: white;
       position: relative;
       font-family: 'Raleway', sans-serif;
       font-weight: 700;
@@ -59,7 +59,7 @@
       align-items: center;
       gap: 0.25rem;
       cursor: pointer;
-      color: #1e40af;
+      color: white;
       user-select: none;
     }
 
@@ -305,14 +305,14 @@
           <circle cx="38" cy="26" r="8" fill="#60a5fa" />
           <circle cx="28" cy="38" r="6" fill="#93c5fd" />
         </svg>
-        <span class="text-xl font-bold text-blue-700 select-none">BubbleLog</span>
+        <span class="text-xl font-bold text-white select-none">BubbleLog</span>
       </div>
 
       <div id="profile-name-dropdown" tabindex="0" aria-haspopup="true" aria-expanded="false" role="button" aria-controls="profile-dropdown" class="flex items-center cursor-pointer select-none ml-auto gap-1 pr-1">
-        <svg xmlns="http://www.w3.org/2000/svg" class="settings-icon text-blue-700" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" aria-label="Settings icon">
+        <svg xmlns="http://www.w3.org/2000/svg" class="settings-icon text-white" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" aria-label="Settings icon">
           <path fill-rule="evenodd" d="M11.078 2.25c-.917 0-1.699.663-1.85 1.567L9.05 4.889c-.02.12-.115.26-.297.348a7.493 7.493 0 0 0-.986.57c-.166.115-.334.126-.45.083L6.3 5.508a1.875 1.875 0 0 0-2.282.819l-.922 1.597a1.875 1.875 0 0 0 .432 2.385l.84.692c.095.078.17.229.154.43a7.598 7.598 0 0 0 0 1.139c.015.2-.059.352-.153.43l-.841.692a1.875 1.875 0 0 0-.432 2.385l.922 1.597a1.875 1.875 0 0 0 2.282.818l1.019-.382c.115-.043.283-.031.45.082.312.214.641.405.985.57.182.088.277.228.297.35l.178 1.071c.151.904.933 1.567 1.85 1.567h1.844c.916 0 1.699-.663 1.85-1.567l.178-1.072c.02-.12.114-.26.297-.349.344-.165.673-.356.985-.57.167-.114.335-.125.45-.082l1.02.382a1.875 1.875 0 0 0 2.28-.819l.923-1.597a1.875 1.875 0 0 0-.432-2.385l-.84-.692c-.095-.078-.17-.229-.154-.43a7.614 7.614 0 0 0 0-1.139c-.016-.2.059-.352.153-.43l.84-.692c.708-.582.891-1.59.433-2.385l-.922-1.597a1.875 1.875 0 0 0-2.282-.818l-1.02.382c-.114.043-.282.031-.449-.083a7.49 7.49 0 0 0-.985-.57c-.183-.087-.277-.227-.297-.348l-.179-1.072a1.875 1.875 0 0 0-1.85-1.567h-1.843ZM12 15.75a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5Z" clip-rule="evenodd"/>
         </svg>
-        <svg xmlns="http://www.w3.org/2000/svg" id="profile-arrow" class="h-4 w-4 text-blue-700 transition-transform duration-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" id="profile-arrow" class="h-4 w-4 text-white transition-transform duration-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
         </svg>
       </div>


### PR DESCRIPTION
## Summary
- update nav color styles for profile section
- use `text-white` classes on navigation icons and logo text

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ae84991083238833d6fe5277f389