### PR TITLE
Apply glass effect to iOS safe area

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,8 @@
       font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, Arial, sans-serif;
       min-height: 100vh;
       margin: 0;
-      padding-top: 56px;
+      padding-top: calc(56px + constant(safe-area-inset-top));
+      padding-top: calc(56px + env(safe-area-inset-top));
     }
 
     nav {
@@ -44,7 +45,9 @@
       z-index: 9999;
       display: flex;
       justify-content: center;
-    }
+      padding-top: constant(safe-area-inset-top);
+      padding-top: env(safe-area-inset-top);
+      }
     #profile-container {
       max-width: 960px;
       margin: 0 auto;


### PR DESCRIPTION
## Summary
- extend body padding to account for iOS safe area insets
- apply same glass background to the safe area above the navigation bar

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68484b13f8208323ad3b16dc9ff18e5d