### PR TITLE
Adjust measurement inputs layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,9 +281,11 @@
         width: 100% !important;
       }
 
-      #auth-form #extra-register-fields,
-      #data-form > div.grid.grid-cols-2 {
+      #auth-form #extra-register-fields {
         grid-template-columns: 1fr !important;
+      }
+      #data-form > div.grid.grid-cols-2 {
+        grid-template-columns: repeat(2, 1fr) !important;
       }
 
       #history-container {
@@ -380,7 +382,7 @@
     <section id="dashboard" class="hidden bg-white rounded-2xl p-4">
       <h2 class="text-xl font-semibold mb-4 text-center text-blue-700">Your Measurements</h2>
       <form id="data-form" class="grid gap-3 mb-6" autocomplete="off" novalidate>
-        <div class="grid grid-cols-3 gap-2 text-gray-700 text-xs font-semibold">
+        <div class="grid grid-cols-2 gap-2 text-gray-700 text-xs font-semibold">
           <label for="ph" class="flex items-center gap-1"><span>pH</span><span>(unitless)</span></label>
           <label for="gh" class="flex items-center gap-1"><span>GH</span><span>(°dH)</span></label>
           <label for="kh" class="flex items-center gap-1"><span>KH</span><span>(°dH)</span></label>
@@ -390,13 +392,13 @@
           <label for="fe2" class="flex items-center gap-1"><span>Fe2</span><span>(mg/L)</span></label>
         </div>
         <div class="grid grid-cols-2 gap-2">
-          <input type="number" step="0.01" id="ph" placeholder="pH" class="border rounded-full px-3 py-2" required />
-          <input type="number" step="0.01" id="gh" placeholder="GH" class="border rounded-full px-3 py-2" required />
-          <input type="number" step="0.01" id="kh" placeholder="KH" class="border rounded-full px-3 py-2" required />
-          <input type="number" step="0.01" id="chlorine" placeholder="Chlorine" class="border rounded-full px-3 py-2" />
-          <input type="number" step="0.01" id="nitrite" placeholder="Nitrite" class="border rounded-full px-3 py-2" />
-          <input type="number" step="0.01" id="nitrate" placeholder="Nitrate" class="border rounded-full px-3 py-2" />
-          <input type="number" step="0.01" id="fe2" placeholder="Fe2" class="border rounded-full px-3 py-2" />
+          <input type="number" step="0.01" id="ph" placeholder="pH" class="border rounded-full px-2 py-1 text-sm" required />
+          <input type="number" step="0.01" id="gh" placeholder="GH" class="border rounded-full px-2 py-1 text-sm" required />
+          <input type="number" step="0.01" id="kh" placeholder="KH" class="border rounded-full px-2 py-1 text-sm" required />
+          <input type="number" step="0.01" id="chlorine" placeholder="Chlorine" class="border rounded-full px-2 py-1 text-sm" />
+          <input type="number" step="0.01" id="nitrite" placeholder="Nitrite" class="border rounded-full px-2 py-1 text-sm" />
+          <input type="number" step="0.01" id="nitrate" placeholder="Nitrate" class="border rounded-full px-2 py-1 text-sm" />
+          <input type="number" step="0.01" id="fe2" placeholder="Fe2" class="border rounded-full px-2 py-1 text-sm" />
         </div>
         <button type="submit" class="mt-4">Save</button>
       </form>


### PR DESCRIPTION
## Summary
- make measurement labels use two columns
- shrink measurement input padding and text size
- keep inputs in two columns on mobile

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68484f9127fc8323bf0f95c3ff3c9cb9